### PR TITLE
support using multiple images for style

### DIFF
--- a/app.js
+++ b/app.js
@@ -30,12 +30,12 @@ app.use('/bower_components', express.static(__dirname + '/bower_components'));
 app.use('/data', express.static(config.get('dataPath')));
 
 var rawBodyParser = bodyParser.raw({limit: '10mb'});
-app.post('/upload/:id/:purpose', rawBodyParser, function(req, res) {
+app.post('/upload/:id/:purpose/:index', rawBodyParser, function(req, res) {
   if (!neuralStyleUtil.validateId(req.params.id)) {
     res.status(400).send('invalid id');
     return;
   }
-  neuralStyleUtil.saveImage(req.params.id, req.params.purpose, req.body, function(err) {
+  neuralStyleUtil.saveImage(req.params.id, req.params.purpose, req.params.index, req.body, function(err) {
     if (err) {
       res.status(500).send(err);
       return;

--- a/neural-style-util.js
+++ b/neural-style-util.js
@@ -4,6 +4,7 @@ var config = require('config');
 var fs = require('fs');
 var imagemagick = require('imagemagick');
 var path = require('path');
+var exec = require('child_process').exec;
 
 try {
   fs.mkdirSync(config.get('dataPath'));
@@ -97,8 +98,8 @@ exports.getImagePathPrefix = function(id, purpose) {
     id + '_' + purpose);
 }
 
-exports.saveImage = function(id, purpose, data, callback) {
-  var outputPath = exports.getImagePathPrefix(id, purpose);
+exports.saveImage = function(id, purpose, index, data, callback) {
+  var outputPath = exports.getImagePathPrefix(id, purpose) + '_' + index;
   async.waterfall([
     function(cb) {
       fs.writeFile(outputPath, data, cb);
@@ -123,35 +124,12 @@ exports.saveImage = function(id, purpose, data, callback) {
 }
 
 exports.findImagePath = function(id, purpose, callback) {
-  var pathPrefix = exports.getImagePathPrefix(id, purpose);
-  function makeExtensionCheck(ext) {
-    return function(cb) {
-      var path = pathPrefix + '.' + ext;
-      fs.stat(path, function(err, stats) {
-        if (!err) {
-          cb(null, path);
-        } else {
-          cb(null, null);
-        }
-      });
-    };
-  }
-  async.parallel([
-    makeExtensionCheck('jpg'),
-    makeExtensionCheck('png'),
-  ], function(err, results) {
-    if (err) {
-      callback(err);
-      return;
-    }
-    var result = _.find(results, function(result) {
-      return result != null;
-    });
-    if (result) {
-      callback(null, result);
-    } else {
-      callback(new Error('Missing image with path prefix ' + pathPrefix));
-    }
+  var fileNamePrefix = id + '_' + purpose;
+  exec("find "+config.get('dataPath')+" -name '"+fileNamePrefix+"*'", function(error, stdout, stderr){
+    var arr = stdout.split('\n');
+    arr.pop();
+    var str = arr.join(',');
+    return callback(error, str);
   });
 }
 

--- a/neural-style-util.js
+++ b/neural-style-util.js
@@ -4,7 +4,6 @@ var config = require('config');
 var fs = require('fs');
 var imagemagick = require('imagemagick');
 var path = require('path');
-var exec = require('child_process').exec;
 
 try {
   fs.mkdirSync(config.get('dataPath'));
@@ -127,10 +126,18 @@ exports.findImagePath = function(id, purpose, callback) {
   var fileNamePrefix = id + '_' + purpose;
   var dataPath = config.get('dataPath');
   fs.readdir(dataPath, function(err, results) {
+    if (err) {
+      callback(err);
+      return;
+    }
     var matches = results.filter(function(fileName) {
-      if (fileName.indexOf(fileNamePrefix) > -1) return true;
+      if (fileName.indexOf(fileNamePrefix) == 0) return true;
       return false;
     });
+    if (matches.length == 0) {
+      callback(new Error('Missing image with path prefix ' + fileNamePrefix));
+      return;
+    }
     matches = matches.map(function(fileName) {
       return dataPath + fileName;
     });

--- a/neural-style-util.js
+++ b/neural-style-util.js
@@ -125,11 +125,16 @@ exports.saveImage = function(id, purpose, index, data, callback) {
 
 exports.findImagePath = function(id, purpose, callback) {
   var fileNamePrefix = id + '_' + purpose;
-  exec("find "+config.get('dataPath')+" -name '"+fileNamePrefix+"*'", function(error, stdout, stderr){
-    var arr = stdout.split('\n');
-    arr.pop();
-    var str = arr.join(',');
-    return callback(error, str);
+  var dataPath = config.get('dataPath');
+  fs.readdir(dataPath, function(err, results) {
+    var matches = results.filter(function(fileName) {
+      if (fileName.indexOf(fileNamePrefix) > -1) return true;
+      return false;
+    });
+    matches = matches.map(function(fileName) {
+      return dataPath + fileName;
+    });
+    return callback(err, matches.join(','));
   });
 }
 

--- a/public/new-image-card.html
+++ b/public/new-image-card.html
@@ -97,11 +97,11 @@
             type: String,
             value: null,
           },
-          contentFile_: {
+          contentFiles_: {
             type: Array,
             value: function() { return []; },
           },
-          styleFile_: {
+          styleFiles_: {
             type: Array,
             value: function() { return []; },
           },
@@ -127,21 +127,24 @@
           },
           uploadProgress_: {
             type: Number,
-            computed: 'computeUploadProgress_(contentUploadProgress_, styleUploadProgress_, contentFile_, styleFile_)',
+            computed: 'computeUploadProgress_(contentUploadProgress_, styleUploadProgress_, contentFiles_, styleFiles_)',
           },
           startButtonDisabled_: {
             type: Boolean,
-            computed: 'computeStartButtonDisabled_(contentFile_, styleFile_, uploading_)',
+            computed: 'computeStartButtonDisabled_(contentFiles_, styleFiles_, uploading_)',
           },
         },
-        computeUploadProgress_: function(contentUploadProgress, styleUploadProgress, contentFile, styleFile) {
+        computeUploadProgress_: function(contentUploadProgress, styleUploadProgress, contentFiles, styleFiles) {
           var progress;
-          if (contentFile.length + styleFile.length == 0) progress = 0;
-          else progress = 100 * (contentUploadProgress + styleUploadProgress) / (contentFile.length + styleFile.length);
+          if (contentFiles.length + styleFiles.length == 0) {
+            progress = 0;
+          } else{
+            progress = 100 * (contentUploadProgress + styleUploadProgress) / (contentFiles.length + styleFiles.length);
+          }
           return progress;
         },
-        computeStartButtonDisabled_: function(contentFile, styleFile, uploading) {
-          return !contentFile.length || !styleFile.length || uploading;
+        computeStartButtonDisabled_: function(contentFiles, styleFiles, uploading) {
+          return !contentFiles.length || !styleFiles.length || uploading;
         },
         finishUpload_: function() {
           this.set('uploading_', false);
@@ -155,9 +158,9 @@
         reset_: function() {
           this.finishUpload_();
           this.$.renderSettings.reset();
-          this.set('contentFile_', []);
+          this.set('contentFiles_', []);
           this.$.contentImagePreview.src = '';
-          this.set('styleFile_', []);
+          this.set('styleFiles_', []);
           this.$.styleImagePreview.src = '';
         },
         chooseContentImage_: function() {
@@ -167,18 +170,18 @@
           this.$.styleFileInput.click();
         },
         contentFileChanged_: function() {
-          this.handleFileInput_('contentFile_', this.$.contentFileInput.files, this.$.contentImagePreview);
+          this.handleFileInput_('contentFiles_', this.$.contentFileInput.files, this.$.contentImagePreview);
         },
         styleFileChanged_: function() {
-          this.handleFileInput_('styleFile_', this.$.styleFileInput.files, this.$.styleImagePreview);
+          this.handleFileInput_('styleFiles_', this.$.styleFileInput.files, this.$.styleImagePreview);
         },
         handleFileInput_: function(fileProperty, files, imageElement) {
+          this.set(fileProperty, []);
           for (var i = 0; i < files.length; i++) {
             if (!files[i].type.startsWith('image/')) {
               return;
             }
           }
-          this.set(fileProperty, []);
           this.set(fileProperty, files);
           var reader = new FileReader();
           reader.onload = function(event) {
@@ -192,10 +195,10 @@
           this.set('id_', Math.round(Math.random() * Math.pow(10, 16)));
           this.set('contentUploadProgress_', 0);
           this.set('styleUploadProgress_', 0);
-          _.each(this.contentFile_, function(file, i, arr){
+          _.each(this.contentFiles_, function(file, i, arr) {
             this.uploadImage_(file, i, arr.length, 'content');
           }, this);
-          _.each(this.styleFile_, function(file, i, arr){
+          _.each(this.styleFiles_, function(file, i, arr) {
             this.uploadImage_(file, i, arr.length, 'style');
           }, this);
         },
@@ -227,10 +230,10 @@
           this.set('$.renderSettings.settings', settings);
         },
         setContentImage: function(imageUrl) {
-          this.setImage_(imageUrl, 'contentFile_', this.$.contentImagePreview);
+          this.setImage_(imageUrl, 'contentFiles_', this.$.contentImagePreview);
         },
         setStyleImage: function(imageUrl) {
-          this.setImage_(imageUrl, 'styleFile_', this.$.styleImagePreview);
+          this.setImage_(imageUrl, 'styleFiles_', this.$.styleImagePreview);
         },
         setImage_: function(imageUrl, fileProperty, imageElement) {
           var xhr = new XMLHttpRequest();

--- a/public/new-image-card.html
+++ b/public/new-image-card.html
@@ -242,7 +242,7 @@
           xhr.responseType = 'blob';
           xhr.onload = function() {
             var blob = xhr.response;
-            this.set(fileProperty, blob);
+            this.set(fileProperty, [blob]);
             var reader = new FileReader();
             reader.onload = function(event) {
               imageElement.src = event.target.result;

--- a/public/new-image-card.html
+++ b/public/new-image-card.html
@@ -138,7 +138,7 @@
           var progress;
           if (contentFiles.length + styleFiles.length == 0) {
             progress = 0;
-          } else{
+          } else {
             progress = 100 * (contentUploadProgress + styleUploadProgress) / (contentFiles.length + styleFiles.length);
           }
           return progress;
@@ -176,6 +176,7 @@
           this.handleFileInput_('styleFiles_', this.$.styleFileInput.files, this.$.styleImagePreview);
         },
         handleFileInput_: function(fileProperty, files, imageElement) {
+          if (files.length == 0) return;
           this.set(fileProperty, []);
           for (var i = 0; i < files.length; i++) {
             if (!files[i].type.startsWith('image/')) {

--- a/public/new-image-card.html
+++ b/public/new-image-card.html
@@ -61,6 +61,7 @@
           <iron-image id="styleImagePreview" class="input-image" sizing="contain"></iron-image>
           <input
              type="file"
+             multiple="true"
              id="styleFileInput"
              class="hidden"
              accept="image/*"
@@ -97,12 +98,12 @@
             value: null,
           },
           contentFile_: {
-            type: Object,
-            value: null,
+            type: Array,
+            value: function() { return []; },
           },
           styleFile_: {
-            type: Object,
-            value: null,
+            type: Array,
+            value: function() { return []; },
           },
           uploading_: {
             type: Boolean,
@@ -126,18 +127,21 @@
           },
           uploadProgress_: {
             type: Number,
-            computed: 'computeUploadProgress_(contentUploadProgress_, styleUploadProgress_)',
+            computed: 'computeUploadProgress_(contentUploadProgress_, styleUploadProgress_, contentFile_, styleFile_)',
           },
           startButtonDisabled_: {
             type: Boolean,
             computed: 'computeStartButtonDisabled_(contentFile_, styleFile_, uploading_)',
           },
         },
-        computeUploadProgress_: function(contentUploadProgress, styleUploadProgress) {
-          return (contentUploadProgress + styleUploadProgress) / 2;
+        computeUploadProgress_: function(contentUploadProgress, styleUploadProgress, contentFile, styleFile) {
+          var progress;
+          if (contentFile.length + styleFile.length == 0) progress = 0;
+          else progress = 100 * (contentUploadProgress + styleUploadProgress) / (contentFile.length + styleFile.length);
+          return progress;
         },
         computeStartButtonDisabled_: function(contentFile, styleFile, uploading) {
-          return contentFile == null || styleFile == null || uploading;
+          return !contentFile.length || !styleFile.length || uploading;
         },
         finishUpload_: function() {
           this.set('uploading_', false);
@@ -151,9 +155,9 @@
         reset_: function() {
           this.finishUpload_();
           this.$.renderSettings.reset();
-          this.set('contentFile_', null);
+          this.set('contentFile_', []);
           this.$.contentImagePreview.src = '';
-          this.set('styleFile_', null);
+          this.set('styleFile_', []);
           this.$.styleImagePreview.src = '';
         },
         chooseContentImage_: function() {
@@ -169,14 +173,13 @@
           this.handleFileInput_('styleFile_', this.$.styleFileInput.files, this.$.styleImagePreview);
         },
         handleFileInput_: function(fileProperty, files, imageElement) {
-          this.set(fileProperty, null);
-          if (files.length != 1) {
-            return;
+          for (var i = 0; i < files.length; i++) {
+            if (!files[i].type.startsWith('image/')) {
+              return;
+            }
           }
-          if (!files[0].type.startsWith('image/')) {
-            return;
-          }
-          this.set(fileProperty, files[0]);
+          this.set(fileProperty, []);
+          this.set(fileProperty, files);
           var reader = new FileReader();
           reader.onload = function(event) {
             imageElement.src = event.target.result;
@@ -187,26 +190,26 @@
           this.set('uploading_', true);
           this.$.uploadProgress.classList.remove('hidden');
           this.set('id_', Math.round(Math.random() * Math.pow(10, 16)));
-          this.uploadImage_(this.contentFile_, 'content');
-          this.uploadImage_(this.styleFile_, 'style');
+          this.set('contentUploadProgress_', 0);
+          this.set('styleUploadProgress_', 0);
+          _.each(this.contentFile_, function(file, i, arr){
+            this.uploadImage_(file, i, arr.length, 'content');
+          }, this);
+          _.each(this.styleFile_, function(file, i, arr){
+            this.uploadImage_(file, i, arr.length, 'style');
+          }, this);
         },
-        uploadImage_: function(file, purpose) {
+        uploadImage_: function(file, index, fileCount, purpose) {
           var xhr = new XMLHttpRequest();
-          xhr.upload.addEventListener('progress', function(event) {
-            if (event.lengthComputable) {
-              var percentage = Math.round((event.loaded * 100) / event.total);
-              this.set(purpose + 'UploadProgress_', percentage);
-            }
-          }.bind(this), false);
           xhr.addEventListener('load', function(event) {
-            this.set(purpose + 'UploadProgress_', 100);
-            this.set(purpose + 'UploadDone_', true);
+            this.set(purpose + 'UploadProgress_', this[purpose + 'UploadProgress_'] + 1);
+            if (this[purpose + 'UploadProgress_'] == fileCount) this.set(purpose + 'UploadDone_', true);
             if (this.contentUploadDone_ && this.styleUploadDone_) {
               this.render_();
               this.finishUpload_();
             }
           }.bind(this), false);
-          xhr.open('POST', '/upload/' + this.id_ + '/' + purpose);
+          xhr.open('POST', '/upload/' + this.id_ + '/' + purpose + '/' + index);
           xhr.setRequestHeader('Content-Type', 'application/octet-stream');
           var reader = new FileReader();
           reader.onload = function(event) {


### PR DESCRIPTION
Can use multiple style images for a task. 

**Code changes**
Both content image and style images are an array of files now. The `upload` call keeps track of their id, purpose, and index. The file select window for style images allow choosing multiple.

`findImagePath` now runs a bash command instead.
